### PR TITLE
*.*: format all go files with gofmt

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,11 +22,11 @@ func printHelper() {
 }
 
 func printUnsupportCmd(cmd string) {
-	fmt.Fprintf(stderr,"unsupport cmd `%s`\n", cmd)
+	fmt.Fprintf(stderr, "unsupport cmd `%s`\n", cmd)
 }
 
 func printHasExistedBreakPoint(place string) {
-	fmt.Fprintf(stderr,"existed breakpoint %s\n", place)
+	fmt.Fprintf(stderr, "existed breakpoint %s\n", place)
 }
 
 func printNotFoundSourceLineErr(place string) {
@@ -34,14 +34,14 @@ func printNotFoundSourceLineErr(place string) {
 }
 
 func printErr(err error) {
-	fmt.Fprintf(stderr,"%s\n", err.Error())
+	fmt.Fprintf(stderr, "%s\n", err.Error())
 }
 
 func printNoProcessErr() {
-	fmt.Fprintf(stderr,"%s\n", NoProcessRuning.Error())
+	fmt.Fprintf(stderr, "%s\n", NoProcessRuning.Error())
 }
 
 func printExit0(opid int) {
-	fmt.Fprintf(stderr,"Process %d has exited with status 0\n", opid)
+	fmt.Fprintf(stderr, "Process %d has exited with status 0\n", opid)
 
 }

--- a/frame.go
+++ b/frame.go
@@ -10,14 +10,14 @@ import (
 
 // http://dwarfstd.org/doc/Dwarf3.pdf
 type CommonInformationEntry struct {
-	length uint32
-	cie_id uint64
-	version byte
-	augmentation string
-	code_alignment_factor uint64
-	data_alignment_factor int64
+	length                  uint32
+	cie_id                  uint64
+	version                 byte
+	augmentation            string
+	code_alignment_factor   uint64
+	data_alignment_factor   int64
 	return_address_register uint64
-	initial_instructions []byte
+	initial_instructions    []byte
 	// `padding`, Enough DW_CFA_nop instructions to make the size of this entry match the length value above.
 }
 
@@ -25,14 +25,14 @@ func (cie *CommonInformationEntry) String() string {
 	if cie == nil {
 		return "`cie == nil` is true, please check cie"
 	}
-	return fmt.Sprintf("len=%d, cie_id=0x%x, " +
-		"versiont=%v, augmentation=%s, code_alignment_factor=%d, " +
-		"data_alignment_factor=%d, return_address_register=0x%x, " +
+	return fmt.Sprintf("len=%d, cie_id=0x%x, "+
+		"versiont=%v, augmentation=%s, code_alignment_factor=%d, "+
+		"data_alignment_factor=%d, return_address_register=0x%x, "+
 		"initial_instructions=%v",
-	cie.length,
-	cie.cie_id, cie.version, cie.augmentation,
-	cie.code_alignment_factor, cie.data_alignment_factor, cie.return_address_register,
-	cie.initial_instructions)
+		cie.length,
+		cie.cie_id, cie.version, cie.augmentation,
+		cie.code_alignment_factor, cie.data_alignment_factor, cie.return_address_register,
+		cie.initial_instructions)
 }
 
 type FrameDescriptionEntry struct {
@@ -58,14 +58,14 @@ type VirtualUnwindFrameInformation struct {
 
 type Frame struct {
 	instructions []byte
-	address uint64
-	cie *CommonInformationEntry
-	Offset int64
-	cfa *DWRule
-	regsRule map[uint64]DWRule
-	regs []uint64
-	framebase uint64
-	loc uint64
+	address      uint64
+	cie          *CommonInformationEntry
+	Offset       int64
+	cfa          *DWRule
+	regsRule     map[uint64]DWRule
+	regs         []uint64
+	framebase    uint64
+	loc          uint64
 }
 
 func parseFrameInformation(buffer *bytes.Buffer) (*VirtualUnwindFrameInformation, error) {
@@ -75,13 +75,12 @@ func parseFrameInformation(buffer *bytes.Buffer) (*VirtualUnwindFrameInformation
 	var (
 		cieEntry *CommonInformationEntry
 		fdeEntry *FrameDescriptionEntry
-		err error
-		info *VirtualUnwindFrameInformation
+		err      error
+		info     *VirtualUnwindFrameInformation
 	)
 
 	info = &VirtualUnwindFrameInformation{}
 	binary.Read(buffer, binary.LittleEndian, &info.len)
-
 
 	tbytes := buffer.Next(4)
 	info.len -= 4
@@ -114,12 +113,12 @@ func parseFrameInformation(buffer *bytes.Buffer) (*VirtualUnwindFrameInformation
 //	 break;
 //	 shift += 7;
 // }
-func DecodeULEB128(buf *bytes.Buffer) (uint64, uint32, error){
+func DecodeULEB128(buf *bytes.Buffer) (uint64, uint32, error) {
 	var (
-		res uint64
-		len uint32
-		err error
-		b byte
+		res   uint64
+		len   uint32
+		err   error
+		b     byte
 		shift uint64
 	)
 	for {
@@ -140,6 +139,7 @@ func DecodeULEB128(buf *bytes.Buffer) (uint64, uint32, error){
 
 	return res, len, nil
 }
+
 // https://en.wikipedia.org/wiki/LEB128
 // result = 0;
 // shift = 0;
@@ -156,10 +156,10 @@ func DecodeULEB128(buf *bytes.Buffer) (uint64, uint32, error){
 //   result |= (~0 << shift);
 func DecodeSLEB128(buf *bytes.Buffer) (int64, uint32, error) {
 	var (
-		res int64
-		len uint32
-		err error
-		b byte
+		res   int64
+		len   uint32
+		err   error
+		b     byte
 		shift uint64
 	)
 
@@ -184,7 +184,7 @@ func DecodeSLEB128(buf *bytes.Buffer) (int64, uint32, error) {
 	return res, len, nil
 }
 
-func parseCommonInformationEntryByte(len uint32, data []byte) (*CommonInformationEntry, error){
+func parseCommonInformationEntryByte(len uint32, data []byte) (*CommonInformationEntry, error) {
 	var (
 		err error
 		str string

--- a/list.go
+++ b/list.go
@@ -12,7 +12,7 @@ import (
 
 func listFileLineByPtracePc(rangeline int) error {
 	pc, err := getPtracePc()
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	filename, lineno, err := bi.pcTofileLine(pc)
@@ -23,7 +23,7 @@ func listFileLineByPtracePc(rangeline int) error {
 	return listFileLine(filename, lineno, rangeline)
 }
 
-func listFileLine(filename string, lineno int, rangeline int) error{
+func listFileLine(filename string, lineno int, rangeline int) error {
 	rangeMin := lineno - rangeline - 1
 	rangeMax := lineno + rangeline - 1
 
@@ -31,7 +31,7 @@ func listFileLine(filename string, lineno int, rangeline int) error{
 		rangeMin = 1
 	}
 
-	if rangeMax - rangeMin <= 0 {
+	if rangeMax-rangeMin <= 0 {
 		return errors.New("not right linenoe or rangeline")
 	}
 
@@ -42,7 +42,7 @@ func listFileLine(filename string, lineno int, rangeline int) error{
 	defer file.Close()
 	reader := bufio.NewReader(file)
 
-	listFileLineBytesSlice := make([]string, 0, rangeMax - rangeMin + 2)
+	listFileLineBytesSlice := make([]string, 0, rangeMax-rangeMin+2)
 
 	listFileLineBytesSlice = append(listFileLineBytesSlice, fmt.Sprintf("list %s:%d\n", filename, lineno))
 	var curLine int

--- a/log/log.go
+++ b/log/log.go
@@ -33,7 +33,6 @@ func init() {
 		level = zapcore.PanicLevel
 	}
 
-
 	/*http.HandleFunc("/debug", func(w http.ResponseWriter, r *http.Request) {
 		lv := r.PostFormValue("level")
 		if lv == "" {

--- a/main.go
+++ b/main.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	bp = &BP{}
-	logger = log.Log
-	bi *BI
-	cmd *exec.Cmd
+	bp       = &BP{}
+	logger   = log.Log
+	bi       *BI
+	cmd      *exec.Cmd
 	execfile string
 
 	stdin  io.Reader
@@ -27,35 +27,35 @@ func main() {
 	var (
 		filename string
 		err      error
-		p *prompt.Prompt
+		p        *prompt.Prompt
 	)
 	stdin = os.Stdin
 	stdout = os.Stdout
 	stderr = os.Stderr
 
 	if err = checkArgs(); err != nil {
-		logger.Error(err.Error(), zap.String("stage","checkArgs"), zap.Strings("args", os.Args))
+		logger.Error(err.Error(), zap.String("stage", "checkArgs"), zap.Strings("args", os.Args))
 		printHelper()
 		return
 	}
 
 	// step 1, get absolute filename
 	if filename, err = absoluteFilename(); err != nil {
-		logger.Error(err.Error(), zap.String("stage","absolute"), zap.String("filename", filename))
+		logger.Error(err.Error(), zap.String("stage", "absolute"), zap.String("filename", filename))
 		printHelper()
 		return
 	}
 
 	// step 2, build the filename into executable file
 	if execfile, err = build(filename); err != nil {
-		logger.Error(err.Error(), zap.String("stage", "build"),zap.String("filename", filename))
+		logger.Error(err.Error(), zap.String("stage", "build"), zap.String("filename", filename))
 		printHelper()
 		return
 	}
 	defer os.Remove(execfile)
 
 	// step 3, analyze executable file; The most import places are "_debug_info", "_debug_line"
-	if bi, err = analyze(execfile);err != nil {
+	if bi, err = analyze(execfile); err != nil {
 		logger.Error(err.Error(), zap.String("stage", "analyze"),
 			zap.String("filename", filename), zap.String("execfile", execfile))
 		printHelper()
@@ -69,7 +69,7 @@ func main() {
 		printHelper()
 		return
 	}
-	fmt.Fprintf(stdout, "trace cur process pid %d\n",cmd.Process.Pid)
+	fmt.Fprintf(stdout, "trace cur process pid %d\n", cmd.Process.Pid)
 
 	// step 5, run prompt. `executor` handle all input
 	p = prompt.New(

--- a/preparations.go
+++ b/preparations.go
@@ -21,7 +21,7 @@ func checkArgs() error {
 	if debug != "debug" {
 		return errors.New("only support `debug`")
 	}
-	if  path.Ext(os.Args[2]) != ".go" {
+	if path.Ext(os.Args[2]) != ".go" {
 		return errors.New("please input .go file")
 	}
 	return nil
@@ -46,9 +46,9 @@ func absoluteFilename() (string, error) {
 	return filename, nil
 }
 
-func build (filename string) (string, error) {
+func build(filename string) (string, error) {
 	base := filepath.Base(filename)
-	execfile := path.Join(os.TempDir(), "__" + base+"__")
+	execfile := path.Join(os.TempDir(), "__"+base+"__")
 
 	args := []string{"build", "-gcflags", "all=-N -l", "-o", execfile, filename}
 
@@ -57,7 +57,7 @@ func build (filename string) (string, error) {
 }
 
 // not supoort arguments of cmds
-func runexec(execfile string) (*exec.Cmd, error){
+func runexec(execfile string) (*exec.Cmd, error) {
 	cmd := exec.Command(execfile)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -77,4 +77,3 @@ func runexec(execfile string) (*exec.Cmd, error){
 	}
 	return cmd, nil
 }
-

--- a/prompt.go
+++ b/prompt.go
@@ -25,7 +25,7 @@ func executor(input string) {
 
 	switch fs {
 	case 'q':
-		if input == "q" || input == "quit"{
+		if input == "q" || input == "quit" {
 			if cmd.Process != nil {
 				if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
 					// printErr(err)
@@ -56,7 +56,7 @@ func executor(input string) {
 				printErr(err)
 				return
 			} else {
-				fmt.Fprintf(stdout,"godbg add %s:%d breakpoint successfully\n",bInfo.filename, bInfo.lineno)
+				fmt.Fprintf(stdout, "godbg add %s:%d breakpoint successfully\n", bInfo.filename, bInfo.lineno)
 			}
 			return
 		}
@@ -85,7 +85,7 @@ func executor(input string) {
 						count++
 						if count == needClearIndex {
 							bp.disableBreakPoint(v)
-							bp.infos = append(bp.infos[:i], bp.infos[(i + 1):len(bp.infos)]...)
+							bp.infos = append(bp.infos[:i], bp.infos[(i+1):len(bp.infos)]...)
 							fmt.Fprintf(stdout, "clear breakpoint %d successfully, resort breakpoint again\n", needClearIndex)
 							return
 						}
@@ -100,11 +100,11 @@ func executor(input string) {
 			for _, v := range bp.infos {
 				if v.kind == USERBPTYPE {
 					count++
-					fmt.Fprintf(stdout,"%-2d. %s:%d, pc %d\n", count, v.filename, v.lineno, v.pc)
+					fmt.Fprintf(stdout, "%-2d. %s:%d, pc %d\n", count, v.filename, v.lineno, v.pc)
 				}
 			}
 			if count == 0 {
-				fmt.Fprintf(stdout,"there is no breakpoint\n")
+				fmt.Fprintf(stdout, "there is no breakpoint\n")
 			}
 			return
 		}
@@ -112,28 +112,28 @@ func executor(input string) {
 			count := 0
 			for _, v := range bp.infos {
 				count++
-				fmt.Fprintf(stdout,"%-2d. %s:%d, pc %d, type %s\n", count, v.filename, v.lineno, v.pc, v.kind.String())
+				fmt.Fprintf(stdout, "%-2d. %s:%d, pc %d, type %s\n", count, v.filename, v.lineno, v.pc, v.kind.String())
 			}
 			if count == 0 {
-				fmt.Fprintf(stdout,"there is no breakpoint\n")
+				fmt.Fprintf(stdout, "there is no breakpoint\n")
 			}
 			return
 		}
 		if len(sps) == 1 && sps[0] == "bt" {
 			var (
-				rbp uint64
-				err error
+				rbp      uint64
+				err      error
 				filename string
-				line int
-				pc uint64
-				f *Function
-				ok bool
+				line     int
+				pc       uint64
+				f        *Function
+				ok       bool
 			)
-			if rbp, err = getPtraceBp();err != nil {
+			if rbp, err = getPtraceBp(); err != nil {
 				printErr(err)
 				return
 			}
-			if pc, err = getPtracePc(); err!= nil {
+			if pc, err = getPtracePc(); err != nil {
 				printErr(err)
 				return
 			}
@@ -179,13 +179,13 @@ func executor(input string) {
 			}
 
 			/*
-			reader = bytes.NewBuffer(original[32:])
-			if err = binary.Read(reader, binary.LittleEndian, &tmp); err != nil {
-				printErr(err)
-				return
-			}
-			fmt.Fprintf(stdout, "%d\n", tmp)
-*/
+				reader = bytes.NewBuffer(original[32:])
+				if err = binary.Read(reader, binary.LittleEndian, &tmp); err != nil {
+					printErr(err)
+					return
+				}
+				fmt.Fprintf(stdout, "%d\n", tmp)
+			*/
 			// strings.NewReader(original[:16])
 
 			return
@@ -199,33 +199,33 @@ func executor(input string) {
 			}
 
 			/*
-			version 1
-			if ok, err := bp.singleStepInstructionWithBreakpointCheck(); err != nil {
-				printErr(err)
-				return
-			} else if ok {
-				if err := bp.Continue(); err != nil {
+				version 1
+				if ok, err := bp.singleStepInstructionWithBreakpointCheck(); err != nil {
 					printErr(err)
 					return
-				}
-				var s syscall.WaitStatus
-				wpid, err := syscall.Wait4(cmd.Process.Pid, &s, syscall.WALL, nil)
-				if err != nil {
-					printErr(err)
-					return
-				}
-				status := (syscall.WaitStatus)(s)
-				if status.Exited() {
-					// TODO
-					if cmd.Process != nil && wpid == cmd.Process.Pid {
-						printExit0(wpid)
-					} else {
-						printExit0(wpid)
+				} else if ok {
+					if err := bp.Continue(); err != nil {
+						printErr(err)
+						return
 					}
-					cmd.Process = nil
-					return
-				}
-			}*/
+					var s syscall.WaitStatus
+					wpid, err := syscall.Wait4(cmd.Process.Pid, &s, syscall.WALL, nil)
+					if err != nil {
+						printErr(err)
+						return
+					}
+					status := (syscall.WaitStatus)(s)
+					if status.Exited() {
+						// TODO
+						if cmd.Process != nil && wpid == cmd.Process.Pid {
+							printExit0(wpid)
+						} else {
+							printExit0(wpid)
+						}
+						cmd.Process = nil
+						return
+					}
+				}*/
 
 			/* version 2 */
 			if err := bp.singleStepInstructionWithBreakpointCheck_v2(); err != nil {
@@ -237,7 +237,7 @@ func executor(input string) {
 				return
 			}
 			var (
-				s syscall.WaitStatus
+				s  syscall.WaitStatus
 				pc uint64
 			)
 			wpid, err := syscall.Wait4(cmd.Process.Pid, &s, syscall.WALL, nil)
@@ -262,7 +262,7 @@ func executor(input string) {
 				printErr(err)
 				return
 			}
-			fmt.Fprintf(stdout,"current process pc = %d\n", pc)
+			fmt.Fprintf(stdout, "current process pc = %d\n", pc)
 			if err = listFileLineByPtracePc(6); err != nil {
 				printErr(err)
 				return
@@ -273,14 +273,14 @@ func executor(input string) {
 		sps := strings.Split(input, " ")
 		if len(sps) == 1 && (sps[0] == "s" || sps[0] == "step") {
 			var (
-				err error
-				filename string
-				lineno int
+				err         error
+				filename    string
+				lineno      int
 				oldfilename string
-				oldlineno int
-				pc uint64
-				info *BInfo
-				ok bool
+				oldlineno   int
+				pc          uint64
+				info        *BInfo
+				ok          bool
 			)
 			if oldfilename, oldlineno, err = bi.getCurFileLineByPtracePc(); err != nil {
 				printErr(err)
@@ -297,7 +297,7 @@ func executor(input string) {
 				}
 
 				if !(filename == oldfilename && lineno == oldlineno) {
-					fmt.Fprintf(stdout,"current process pc = %d\n", pc)
+					fmt.Fprintf(stdout, "current process pc = %d\n", pc)
 					if err = listFileLineByPtracePc(6); err != nil {
 						printErr(err)
 						return
@@ -305,7 +305,7 @@ func executor(input string) {
 					return
 				}
 				if info, ok = bp.findBreakPoint(pc - 1); ok {
-					if err = bp.disableBreakPoint(info); err !=nil {
+					if err = bp.disableBreakPoint(info); err != nil {
 						printErr(err)
 						return
 					}
@@ -340,14 +340,14 @@ func executor(input string) {
 		sps := strings.Split(input, " ")
 		if len(sps) == 1 && (sps[0] == "n" || sps[0] == "next") {
 			var (
-				err error
-				pc uint64
-				info *BInfo
-				ok bool
-				filename string
-				lineno int
+				err         error
+				pc          uint64
+				info        *BInfo
+				ok          bool
+				filename    string
+				lineno      int
 				oldfilename string
-				oldlineno int
+				oldlineno   int
 
 				//f *Function
 				inst x86asm.Inst
@@ -369,7 +369,7 @@ func executor(input string) {
 				}
 				defer bp.enableBreakPoint(info)
 			}
-			if oldfilename, oldlineno , err = bi.pcTofileLine(pc); err != nil{
+			if oldfilename, oldlineno, err = bi.pcTofileLine(pc); err != nil {
 				printErr(err)
 				return
 			}
@@ -463,7 +463,7 @@ func executor(input string) {
 						}
 						return
 					}*/
-					if filename, lineno , err = bi.pcTofileLine(pc + uint64(inst.Len)); err != nil{
+					if filename, lineno, err = bi.pcTofileLine(pc + uint64(inst.Len)); err != nil {
 						printErr(err)
 						return
 					}
@@ -559,11 +559,11 @@ func executor(input string) {
 		sps := strings.Split(input, " ")
 		if len(sps) == 2 && (sps[0] == "p" || sps[0] == "print") {
 			var (
-				v string
-				pc uint64
-				err error
-				ok bool
-				f *Function
+				v     string
+				pc    uint64
+				err   error
+				ok    bool
+				f     *Function
 				frame *Frame
 			)
 			v = sps[1]
@@ -584,7 +584,7 @@ func executor(input string) {
 			}
 			for _, fv := range f.variables {
 				isFound := false
-				if field := fv.AttrField(dwarf.AttrName);field != nil {
+				if field := fv.AttrField(dwarf.AttrName); field != nil {
 					if fieldstr, ok := field.Val.(string); ok && fieldstr == v {
 						isFound = true
 					}
@@ -601,11 +601,11 @@ func executor(input string) {
 					}
 					switch opcode {
 					case DW_OP_fbreg:
-						num, _,_ := DecodeSLEB128(buf)
+						num, _, _ := DecodeSLEB128(buf)
 						address := int64(frame.framebase) + num
 						// if the type is `string`
 						val := make([]byte, 8)
-						if _, err = syscall.PtracePeekData(cmd.Process.Pid, uintptr(address) + uintptr(8), val); err != nil {
+						if _, err = syscall.PtracePeekData(cmd.Process.Pid, uintptr(address)+uintptr(8), val); err != nil {
 							printErr(err)
 							return
 						}
@@ -657,7 +657,7 @@ func complete(docs prompt.Document) []prompt.Suggest {
 					if filename[0] == '/' {
 						filename = filename[1:]
 					}
-					s = append(s, prompt.Suggest{Text: filename, Description:""})
+					s = append(s, prompt.Suggest{Text: filename, Description: ""})
 				} else {
 
 					inputPrefix := sps[1]
@@ -688,7 +688,7 @@ func complete(docs prompt.Document) []prompt.Suggest {
 }
 
 const (
-	_AT_NULL_AMD64 = 0
+	_AT_NULL_AMD64  = 0
 	_AT_ENTRY_AMD64 = 9
 )
 

--- a/register.go
+++ b/register.go
@@ -2,7 +2,7 @@ package main
 
 import "syscall"
 
-func getRegisters() (syscall.PtraceRegs, error){
+func getRegisters() (syscall.PtraceRegs, error) {
 	var prs syscall.PtraceRegs
 	if cmd.Process == nil {
 		return prs, NoProcessRuning
@@ -34,7 +34,7 @@ func setPcRegister(pc uint64) error {
 	return syscall.PtraceSetRegs(cmd.Process.Pid, &prs)
 }
 
-func getPtraceBp() (uint64, error){
+func getPtraceBp() (uint64, error) {
 	var (
 		prs syscall.PtraceRegs
 		err error

--- a/test_file/t2.go
+++ b/test_file/t2.go
@@ -3,7 +3,7 @@ package main
 import "fmt"
 
 func p() {
-	for i := 0;i < 3;i++ {
+	for i := 0; i < 3; i++ {
 		fmt.Println(i)
 	}
 }

--- a/test_file/t5.go
+++ b/test_file/t5.go
@@ -9,7 +9,7 @@ type A struct {
 func main() {
 	godbgvstr := "hello world"
 	godbgvint := uint64(100)
-	godbgvstruct := A{a : "hello a"}
+	godbgvstruct := A{a: "hello a"}
 
 	fmt.Printf("%s %d %v\n", godbgvstr, godbgvint, godbgvstruct)
 }


### PR DESCRIPTION
I used vim-go before and there were changes in diffrent usage of gofmt.
The current version of go is 1.15.2 and we just gofmt all go files.